### PR TITLE
Fix the package name on the types definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'react-sketch' {
+declare module 'react-sketch-whiteboard' {
 	import * as React from 'react'
 
 	export class SketchField extends React.PureComponent<{


### PR DESCRIPTION
This is needed, so we can import it without errors on typescript code and have code completion and type checking.